### PR TITLE
Unstable package dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rryam/VecturaKit.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "2a2b606936c62e65ad8dd9e8cd280b123608768d"
+        "revision" : "3d8ccfa92076dbbf81783397a43ab3e7c1543bcd",
+        "version" : "2.5.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/rryam/VecturaKit.git",
-            branch: "main"
+            from: "2.5.1"
         )
     ],
     targets: [


### PR DESCRIPTION
Update VecturaKit dependency to a stable version to resolve Swift Package Manager's unstable dependency error.

This PR partially resolves a Swift Package Manager dependency resolution error where stable packages (LumoKit 1.1.1+) cannot depend on unstable packages (branch references). This change updates `VecturaKit` from a `branch: "main"` reference to a stable `from: "2.5.1"` version.

The `rudrankriyam/PicoDocs` dependency still uses `branch: "main"` and lacks stable tags, which prevents a full resolution within this repository. A stable tag needs to be created on `rudrankriyam/PicoDocs` for a complete fix.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6ee5d42-6771-4cb0-93f5-e166019b108a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b6ee5d42-6771-4cb0-93f5-e166019b108a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

