### PR TITLE
Audit follow-up: refactor parse path and harden API validation

### DIFF
--- a/Sources/LumoKit/LumoKit.swift
+++ b/Sources/LumoKit/LumoKit.swift
@@ -38,23 +38,7 @@ public final class LumoKit {
         url: URL,
         chunkingConfig: ChunkingConfig? = nil
     ) async throws -> [UUID] {
-        // Validate URL
-        guard url.isFileURL else {
-            throw LumoKitError.invalidURL
-        }
-
-        guard FileManager.default.fileExists(atPath: url.path) else {
-            throw LumoKitError.fileNotFound
-        }
-
-        let chunks = try await parseDocument(
-            from: url,
-            chunkingConfig: chunkingConfig
-        )
-
-        guard !chunks.isEmpty else {
-            throw LumoKitError.emptyDocument
-        }
+        let chunks = try await parseChunks(from: url, chunkingConfig: chunkingConfig)
         let texts = chunks.map { $0.text }
         return try await vectura.addDocuments(texts: texts)
     }
@@ -67,12 +51,52 @@ public final class LumoKit {
     /// - Returns: Array of chunks with metadata (text, position, overlap info, content type, etc.)
     /// - Throws: `LumoKitError.invalidURL` if the URL is not a file URL
     /// - Throws: `LumoKitError.fileNotFound` if the file does not exist
+    /// - Throws: `LumoKitError.emptyDocument` if the document has no valid content
     /// - Throws: `LumoKitError.unsupportedFileType` if the file type is not supported
     public func parseDocument(
         from url: URL,
         chunkingConfig: ChunkingConfig? = nil
     ) async throws -> [Chunk] {
-        // Validate URL
+        let chunks = try await parseChunks(from: url, chunkingConfig: chunkingConfig)
+
+        var chunksWithSource: [Chunk] = []
+        chunksWithSource.reserveCapacity(chunks.count)
+
+        let sourceName = url.lastPathComponent
+        for chunk in chunks {
+            chunksWithSource.append(
+                Chunk(
+                    text: chunk.text,
+                    metadata: ChunkMetadata(
+                        index: chunk.metadata.index,
+                        startPosition: chunk.metadata.startPosition,
+                        endPosition: chunk.metadata.endPosition,
+                        hasOverlapWithPrevious: chunk.metadata.hasOverlapWithPrevious,
+                        hasOverlapWithNext: chunk.metadata.hasOverlapWithNext,
+                        contentType: chunk.metadata.contentType,
+                        source: sourceName
+                    )
+                )
+            )
+        }
+        return chunksWithSource
+    }
+
+    private func parseChunks(
+        from url: URL,
+        chunkingConfig: ChunkingConfig?
+    ) async throws -> [Chunk] {
+        try validateInputURL(url)
+        let fullContent = try await loadDocumentContent(from: url)
+        let config = chunkingConfig ?? defaultChunkingConfig
+        let chunks = try chunkText(fullContent, config: config)
+        guard !chunks.isEmpty else {
+            throw LumoKitError.emptyDocument
+        }
+        return chunks
+    }
+
+    private func validateInputURL(_ url: URL) throws {
         guard url.isFileURL else {
             throw LumoKitError.invalidURL
         }
@@ -80,44 +104,31 @@ public final class LumoKit {
         guard FileManager.default.fileExists(atPath: url.path) else {
             throw LumoKitError.fileNotFound
         }
+    }
 
+    private func loadDocumentContent(from url: URL) async throws -> String {
         let doc = await PicoDocument(url: url)
 
         // Check if file type is supported
         try await checkDocumentStatus(doc, stage: "initialization")
 
         await doc.fetch()
-
-        // Check status after fetch
         try await checkDocumentStatus(doc, stage: "fetch")
 
         await doc.parse(to: .markdown)
-
-        // Check status after parse
         try await checkDocumentStatus(doc, stage: "parse")
 
-        guard let fullContent = await doc.exportedContent?.joined(separator: "\n") else {
+        guard let exportedContent = await doc.exportedContent else {
             throw LumoKitError.emptyDocument
         }
 
-        let config = chunkingConfig ?? defaultChunkingConfig
-        let chunks = try chunkText(fullContent, config: config)
-
-        // Populate source metadata from URL
-        let source = url.lastPathComponent
-        return chunks.map { chunk in
-            Chunk(
-                text: chunk.text,
-                metadata: ChunkMetadata(
-                    index: chunk.metadata.index,
-                    startPosition: chunk.metadata.startPosition,
-                    endPosition: chunk.metadata.endPosition,
-                    hasOverlapWithPrevious: chunk.metadata.hasOverlapWithPrevious,
-                    hasOverlapWithNext: chunk.metadata.hasOverlapWithNext,
-                    contentType: chunk.metadata.contentType,
-                    source: source
-                )
-            )
+        switch exportedContent.count {
+        case 0:
+            throw LumoKitError.emptyDocument
+        case 1:
+            return exportedContent[0]
+        default:
+            return exportedContent.joined(separator: "\n")
         }
     }
 
@@ -142,10 +153,10 @@ public final class LumoKit {
             case .emptyDocument:
                 throw LumoKitError.emptyDocument
             default:
-                throw LumoKitError.chunkingFailed(strategy: "PicoDocs", underlyingError: error)
+                throw LumoKitError.chunkingFailed(strategy: "PicoDocs.\(stage)", underlyingError: error)
             }
         } else {
-            throw LumoKitError.chunkingFailed(strategy: "PicoDocs", underlyingError: error)
+            throw LumoKitError.chunkingFailed(strategy: "PicoDocs.\(stage)", underlyingError: error)
         }
     }
 

--- a/Tests/LumoKitTests/PublicAPITests.swift
+++ b/Tests/LumoKitTests/PublicAPITests.swift
@@ -136,3 +136,63 @@ func testLumoKitStrategyFactory() {
     let semanticStrategy = ChunkingStrategyFactory.strategy(for: .semantic)
     #expect(semanticStrategy is SemanticChunker)
 }
+
+@Test("LumoKit parseDocument URL validation")
+func testLumoKitParseDocumentURLValidation() async throws {
+    let config = try VecturaConfig(name: "test-db-parse-url-validation")
+    let lumoKit = try await LumoKit(config: config)
+
+    let nonFileURL = URL(string: "https://example.com/test.txt")!
+    await #expect(throws: LumoKitError.invalidURL) {
+        _ = try await lumoKit.parseDocument(from: nonFileURL)
+    }
+}
+
+@Test("LumoKit parseAndIndex URL validation")
+func testLumoKitParseAndIndexURLValidation() async throws {
+    let config = try VecturaConfig(name: "test-db-index-url-validation")
+    let lumoKit = try await LumoKit(config: config)
+
+    let nonFileURL = URL(string: "https://example.com/test.txt")!
+    await #expect(throws: LumoKitError.invalidURL) {
+        _ = try await lumoKit.parseAndIndex(url: nonFileURL)
+    }
+}
+
+@Test("LumoKit file not found validation")
+func testLumoKitFileNotFoundValidation() async throws {
+    let config = try VecturaConfig(name: "test-db-file-not-found")
+    let lumoKit = try await LumoKit(config: config)
+
+    let missingURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("lumo-missing-\(UUID().uuidString).txt")
+
+    await #expect(throws: LumoKitError.fileNotFound) {
+        _ = try await lumoKit.parseDocument(from: missingURL)
+    }
+
+    await #expect(throws: LumoKitError.fileNotFound) {
+        _ = try await lumoKit.parseAndIndex(url: missingURL)
+    }
+}
+
+@Test("LumoKit empty file handling")
+func testLumoKitEmptyFileHandling() async throws {
+    let config = try VecturaConfig(name: "test-db-empty-file")
+    let lumoKit = try await LumoKit(config: config)
+
+    let tempDir = FileManager.default.temporaryDirectory
+    let emptyFile = tempDir.appendingPathComponent("lumo-empty-\(UUID().uuidString).txt")
+    try "".write(to: emptyFile, atomically: true, encoding: .utf8)
+    defer {
+        try? FileManager.default.removeItem(at: emptyFile)
+    }
+
+    await #expect(throws: LumoKitError.emptyDocument) {
+        _ = try await lumoKit.parseDocument(from: emptyFile)
+    }
+
+    await #expect(throws: LumoKitError.emptyDocument) {
+        _ = try await lumoKit.parseAndIndex(url: emptyFile)
+    }
+}


### PR DESCRIPTION
## Summary
Second-pass audit focused on non-chunking paths (`parseAndIndex`, document parse lifecycle, and API validation behavior).

This PR addresses redundant work and a correctness gap around empty parsed output.

### Changes
- Refactored document parsing into a shared internal path:
  - `parseChunks(from:chunkingConfig:)`
  - `validateInputURL(_:)`
  - `loadDocumentContent(from:)`
- Removed duplicated URL/file validation between `parseAndIndex` and `parseDocument`.
- Removed unnecessary parse-and-remap path in `parseAndIndex` (it no longer calls `parseDocument` just to discard metadata).
- Hardened empty-content behavior:
  - If parsed content produces zero chunks, both `parseDocument` and `parseAndIndex` now throw `LumoKitError.emptyDocument`.
- Added richer PicoDocs error context by including stage in wrapped strategy name (`PicoDocs.<stage>`).
- Added API regression tests for:
  - `invalidURL` on `parseDocument`
  - `invalidURL` on `parseAndIndex`
  - `fileNotFound` on both APIs
  - empty file handling on both APIs

## Baseline vs After (same machine, median of 5)
Measured via `/usr/bin/time -lp swift test --skip-build --filter <testName>`.

- `testLumoKitSourceMetadata`: `2.61s` -> `2.56s` (`+1.92%`)
- `testLumoKitSearchParameterValidation`: `2.57s` -> `2.59s` (`-0.78%`)

Note: second metric is within run-to-run noise; primary intent here is correctness + removal of redundant path work.

## Validation
- `swiftlint`
- `swift build`
- `swift test`
- `swift test -c release`
- `swift test --skip-build --filter testConcurrentChunking` (5 consecutive runs)
- `swift test --skip-build --filter testMemoryPressure` (3 consecutive runs)

All passed.
