### PR TITLE
Add configurable embedding model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ Deepen your understanding of AI and iOS development with these books:
 
 ```swift
 public final class LumoKit {
-    public init(config: VecturaConfig, chunkingConfig: ChunkingConfig? = nil) async throws
+    public init(
+        config: VecturaConfig,
+        chunkingConfig: ChunkingConfig? = nil,
+        modelSource: VecturaModelSource = .default
+    ) async throws
 
     public func parseAndIndex(url: URL, chunkingConfig: ChunkingConfig? = nil) async throws -> [UUID]
     public func parseDocument(from url: URL, chunkingConfig: ChunkingConfig? = nil) async throws -> [Chunk]
@@ -134,6 +138,13 @@ let chunkingConfig = ChunkingConfig(
 let lumoKit = try await LumoKit(
     config: vecturaConfig,
     chunkingConfig: chunkingConfig
+)
+
+// Optionally choose a specific embedding model
+let customModelLumoKit = try await LumoKit(
+    config: vecturaConfig,
+    chunkingConfig: chunkingConfig,
+    modelSource: .id("minishlab/potion-retrieval-32M")
 )
 
 // Parse and index a document

--- a/README.md
+++ b/README.md
@@ -140,9 +140,18 @@ let lumoKit = try await LumoKit(
     chunkingConfig: chunkingConfig
 )
 
-// Optionally choose a specific embedding model
+// Optionally choose a specific embedding model.
+// Use a separate store when switching models so stored vector dimensions stay consistent.
+let customModelConfig = VecturaConfig(
+    name: "knowledge-base-retrieval",
+    searchOptions: .init(
+        defaultNumResults: 10,
+        minThreshold: 0.7
+    )
+)
+
 let customModelLumoKit = try await LumoKit(
-    config: vecturaConfig,
+    config: customModelConfig,
     chunkingConfig: chunkingConfig,
     modelSource: .id("minishlab/potion-retrieval-32M")
 )

--- a/Sources/LumoKit/LumoKit.swift
+++ b/Sources/LumoKit/LumoKit.swift
@@ -15,12 +15,14 @@ public final class LumoKit {
     /// - Parameters:
     ///   - config: Configuration for the VecturaKit vector database
     ///   - chunkingConfig: Configuration for text chunking (uses defaults if not provided)
+    ///   - modelSource: The embedding model source used by `SwiftEmbedder`
     /// - Throws: Errors from VecturaKit initialization
     public init(
         config: VecturaConfig,
-        chunkingConfig: ChunkingConfig? = nil
+        chunkingConfig: ChunkingConfig? = nil,
+        modelSource: VecturaModelSource = .default
     ) async throws {
-        let embedder = SwiftEmbedder()
+        let embedder = SwiftEmbedder(modelSource: modelSource)
         self.vectura = try await VecturaKit(config: config, embedder: embedder)
         self.defaultChunkingConfig = try chunkingConfig ?? ChunkingConfig()
     }

--- a/Tests/LumoKitTests/PublicAPITests.swift
+++ b/Tests/LumoKitTests/PublicAPITests.swift
@@ -40,6 +40,31 @@ func testLumoKitPublicAPI() async throws {
     try await lumoKit.resetDB()
 }
 
+@Test("LumoKit supports custom embedding model selection")
+func testLumoKitCustomModelSource() async throws {
+    let config = try VecturaConfig(name: "test-db-custom-model")
+    let lumoKit = try await LumoKit(
+        config: config,
+        modelSource: .id("minishlab/potion-base-2M")
+    )
+
+    let ids = try await lumoKit.addDocuments(texts: [
+        "Milk, eggs, and bread from the grocery store.",
+        "The team discussed the product roadmap and Q3 priorities."
+    ])
+
+    #expect(ids.count == 2, "Should index documents with the selected embedding model")
+
+    let results = try await lumoKit.semanticSearch(
+        query: "What did the team discuss?",
+        numResults: 1,
+        threshold: 0.0
+    )
+    #expect(!results.isEmpty, "Should return search results when using a custom model source")
+
+    try await lumoKit.resetDB()
+}
+
 @Test("LumoKit source metadata")
 func testLumoKitSourceMetadata() async throws {
     let config = try VecturaConfig(name: "test-db-source")

--- a/Tests/LumoKitTests/PublicAPITests.swift
+++ b/Tests/LumoKitTests/PublicAPITests.swift
@@ -42,7 +42,17 @@ func testLumoKitPublicAPI() async throws {
 
 @Test("LumoKit supports custom embedding model selection")
 func testLumoKitCustomModelSource() async throws {
-    let config = try VecturaConfig(name: "test-db-custom-model")
+    let storageDirectory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("lumo-custom-model-\(UUID().uuidString)", isDirectory: true)
+    defer {
+        try? FileManager.default.removeItem(at: storageDirectory)
+    }
+
+    let config = try VecturaConfig(
+        name: "test-db-custom-model",
+        directoryURL: storageDirectory,
+        dimension: 64
+    )
     let lumoKit = try await LumoKit(
         config: config,
         modelSource: .id("minishlab/potion-base-2M")


### PR DESCRIPTION
## Summary
- add a backward-compatible `modelSource` parameter to `LumoKit`'s initializer
- keep the current default behavior by defaulting `modelSource` to `.default`
- document custom embedding model selection in the README
- add a public API test covering custom model selection

## Testing
- `swift test`

## Notes
- existing call sites continue to work unchanged because the new parameter is defaulted
- custom model selection is exposed through `VecturaModelSource`, which maps cleanly onto `SwiftEmbedder(modelSource:)`
