### PR TITLE
Add custom Vectura embedder injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ public final class LumoKit {
         modelSource: VecturaModelSource = .default
     ) async throws
 
+    public init(
+        config: VecturaConfig,
+        chunkingConfig: ChunkingConfig? = nil,
+        embedder: VecturaEmbedder
+    ) async throws
+
     public func parseAndIndex(url: URL, chunkingConfig: ChunkingConfig? = nil) async throws -> [UUID]
     public func parseDocument(from url: URL, chunkingConfig: ChunkingConfig? = nil) async throws -> [Chunk]
 
@@ -156,6 +162,21 @@ let customModelLumoKit = try await LumoKit(
     modelSource: .id("minishlab/potion-retrieval-32M")
 )
 
+// Or provide any Vectura embedder directly
+let customEmbedderConfig = VecturaConfig(
+    name: "knowledge-base-multilingual",
+    searchOptions: .init(
+        defaultNumResults: 10,
+        minThreshold: 0.7
+    )
+)
+
+let customEmbedderLumoKit = try await LumoKit(
+    config: customEmbedderConfig,
+    chunkingConfig: chunkingConfig,
+    embedder: SwiftEmbedder(modelSource: .id("intfloat/multilingual-e5-small"))
+)
+
 // Parse and index a document
 let url = URL(fileURLWithPath: "/path/to/document.pdf")
 try await lumoKit.parseAndIndex(url: url)
@@ -170,6 +191,61 @@ let results = try await lumoKit.semanticSearch(
 for result in results {
     print(result.text)
 }
+```
+
+### Custom Embedder Examples
+
+LumoKit can also accept any embedder that conforms to `VecturaEmbedder`.
+
+#### Use `NLContextualEmbedder`
+
+```swift
+import LumoKit
+import VecturaKit
+import VecturaNLKit
+
+let embedder = try await NLContextualEmbedder(language: .english)
+let lumoKit = try await LumoKit(
+    config: vecturaConfig,
+    chunkingConfig: chunkingConfig,
+    embedder: embedder
+)
+```
+
+#### Use `OpenAICompatibleEmbedder`
+
+```swift
+import LumoKit
+import VecturaKit
+import VecturaOAIKit
+
+let embedder = OpenAICompatibleEmbedder(
+    baseURL: "https://api.openai.com/v1",
+    model: "text-embedding-3-small",
+    apiKey: "<api-key>"
+)
+
+let lumoKit = try await LumoKit(
+    config: vecturaConfig,
+    chunkingConfig: chunkingConfig,
+    embedder: embedder
+)
+```
+
+#### Use `MLXEmbedder`
+
+```swift
+import LumoKit
+import VecturaKit
+import VecturaMLXKit
+import MLXEmbedders
+
+let embedder = try await MLXEmbedder(configuration: .multilingual_e5_small)
+let lumoKit = try await LumoKit(
+    config: vecturaConfig,
+    chunkingConfig: chunkingConfig,
+    embedder: embedder
+)
 ```
 
 ## Chunking Strategies

--- a/Sources/LumoKit/LumoKit.swift
+++ b/Sources/LumoKit/LumoKit.swift
@@ -17,12 +17,35 @@ public final class LumoKit {
     ///   - chunkingConfig: Configuration for text chunking (uses defaults if not provided)
     ///   - modelSource: The embedding model source used by `SwiftEmbedder`
     /// - Throws: Errors from VecturaKit initialization
-    public init(
+    public convenience init(
         config: VecturaConfig,
         chunkingConfig: ChunkingConfig? = nil,
         modelSource: VecturaModelSource = .default
     ) async throws {
         let embedder = SwiftEmbedder(modelSource: modelSource)
+        try await self.init(
+            config: config,
+            chunkingConfig: chunkingConfig,
+            embedder: embedder
+        )
+    }
+
+    /// Initializes a new LumoKit instance with a custom Vectura embedder.
+    ///
+    /// This overload unlocks the full range of embedders supported by VecturaKit,
+    /// including `NLContextualEmbedder`, `OpenAICompatibleEmbedder`, `MLXEmbedder`,
+    /// and custom `VecturaEmbedder` implementations.
+    ///
+    /// - Parameters:
+    ///   - config: Configuration for the VecturaKit vector database
+    ///   - chunkingConfig: Configuration for text chunking (uses defaults if not provided)
+    ///   - embedder: The embedder used to generate vector embeddings
+    /// - Throws: Errors from VecturaKit initialization
+    public init(
+        config: VecturaConfig,
+        chunkingConfig: ChunkingConfig? = nil,
+        embedder: VecturaEmbedder
+    ) async throws {
         self.vectura = try await VecturaKit(config: config, embedder: embedder)
         self.defaultChunkingConfig = try chunkingConfig ?? ChunkingConfig()
     }

--- a/Tests/LumoKitTests/PublicAPITests.swift
+++ b/Tests/LumoKitTests/PublicAPITests.swift
@@ -5,6 +5,22 @@ import Foundation
 
 // MARK: - Public API Tests
 
+private actor MockEmbedder: VecturaEmbedder {
+    let dimension: Int = 2
+
+    func embed(texts: [String]) async throws -> [[Float]] {
+        texts.map(embedding(for:))
+    }
+
+    private func embedding(for text: String) -> [Float] {
+        let normalized = text.lowercased()
+        if normalized.contains("team") || normalized.contains("roadmap") || normalized.contains("q3") {
+            return [1, 0]
+        }
+        return [0, 1]
+    }
+}
+
 @Test("LumoKit public API")
 func testLumoKitPublicAPI() async throws {
     let config = try VecturaConfig(name: "test-db")
@@ -71,6 +87,46 @@ func testLumoKitCustomModelSource() async throws {
         threshold: 0.0
     )
     #expect(!results.isEmpty, "Should return search results when using a custom model source")
+
+    try await lumoKit.resetDB()
+}
+
+@Test("LumoKit supports custom embedder injection")
+func testLumoKitCustomEmbedder() async throws {
+    let storageDirectory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("lumo-custom-embedder-\(UUID().uuidString)", isDirectory: true)
+    defer {
+        try? FileManager.default.removeItem(at: storageDirectory)
+    }
+
+    let config = try VecturaConfig(
+        name: "test-db-custom-embedder",
+        directoryURL: storageDirectory,
+        dimension: 2
+    )
+    let lumoKit = try await LumoKit(
+        config: config,
+        embedder: MockEmbedder()
+    )
+
+    let ids = try await lumoKit.addDocuments(texts: [
+        "Milk, eggs, and bread from the grocery store.",
+        "The team discussed the product roadmap and Q3 priorities."
+    ])
+
+    #expect(ids.count == 2, "Should index documents with a custom embedder")
+
+    let results = try await lumoKit.semanticSearch(
+        query: "What did the team discuss?",
+        numResults: 1,
+        threshold: 0.0
+    )
+
+    #expect(results.count == 1, "Should return a top match for the custom embedder")
+    #expect(
+        results.first?.text == "The team discussed the product roadmap and Q3 priorities.",
+        "Should surface the document preferred by the custom embedder"
+    )
 
     try await lumoKit.resetDB()
 }


### PR DESCRIPTION
## Summary
- add a new `embedder:` initializer overload that accepts any `VecturaEmbedder`
- keep the existing `modelSource` initializer as a convenience wrapper around `SwiftEmbedder`
- document how to use NL, OpenAI-compatible, MLX, and custom embedders
- add a public API test covering custom embedder injection

## Testing
- `swift test`

## Notes
- this complements the existing `modelSource` API by unlocking the full range of embedder types exposed by VecturaKit
- existing call sites continue to work unchanged