### PR TITLE
Migrate to VecturaKit 6.x (source SwiftEmbedder from VecturaEmbeddingsKit)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,11 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/rryam/VecturaKit.git",
-            branch: "main"
+            from: "6.0.0"
+        ),
+        .package(
+            url: "https://github.com/rryam/VecturaEmbeddingsKit.git",
+            from: "1.1.0"
         )
     ],
     targets: [
@@ -29,7 +33,8 @@ let package = Package(
             name: "LumoKit",
             dependencies: [
                 .product(name: "PicoDocs", package: "PicoDocs"),
-                .product(name: "VecturaKit", package: "VecturaKit")
+                .product(name: "VecturaKit", package: "VecturaKit"),
+                .product(name: "VecturaEmbeddingsKit", package: "VecturaEmbeddingsKit")
             ]),
         .testTarget(
             name: "LumoKitTests",

--- a/Sources/LumoKit/LumoKit.swift
+++ b/Sources/LumoKit/LumoKit.swift
@@ -1,5 +1,6 @@
 import PicoDocs
 import VecturaKit
+import VecturaEmbeddingsKit
 import Foundation
 
 /// Main entry point for LumoKit document parsing and semantic search.


### PR DESCRIPTION
## Summary

VecturaKit 6.x moved the swift-embeddings backend - `SwiftEmbedder` and `VecturaModelSource` - out of core into the separate `VecturaEmbeddingsKit` package. LumoKit's convenience initializer still references those types, so LumoKit no longer compiles against VecturaKit >= 6.0.0:

```
LumoKit.swift:23: cannot find type 'VecturaModelSource' in scope
```

This PR migrates LumoKit to the new layout.

## Changes

- **Package.swift**: bump the VecturaKit requirement from `branch: "main"` to `from: "6.0.0"`, and add `VecturaEmbeddingsKit` (`from: "1.1.0"`) as a dependency + product of the `LumoKit` target.
- **LumoKit.swift**: add `import VecturaEmbeddingsKit` so the convenience initializer can resolve `SwiftEmbedder` / `VecturaModelSource` from their new home.

## API impact

None. The public API is unchanged - `SwiftEmbedder(modelSource:)` and `VecturaModelSource.default` keep the same signatures, now vended by VecturaEmbeddingsKit. The `VecturaEmbedder` / `VecturaConfig` / `VecturaKit(config:embedder:)` types LumoKit relies on remain in VecturaKit core.

Consumers that call the `modelSource:` convenience initializer should `import VecturaEmbeddingsKit` to construct a `VecturaModelSource`.

## Testing

`swift build` succeeds against VecturaKit 6.1.0 + VecturaEmbeddingsKit 1.1.0 (swift-embeddings 0.1.0).